### PR TITLE
fix: activity find all start and end dates

### DIFF
--- a/tntconcept-binnacle/src/main/kotlin/com/autentia/tnt/binnacle/repositories/ActivityRepositorySecured.kt
+++ b/tntconcept-binnacle/src/main/kotlin/com/autentia/tnt/binnacle/repositories/ActivityRepositorySecured.kt
@@ -5,6 +5,7 @@ import com.autentia.tnt.binnacle.core.domain.ActivityTimeOnly
 import com.autentia.tnt.binnacle.entities.Activity
 import com.autentia.tnt.binnacle.entities.ApprovalState
 import com.autentia.tnt.binnacle.repositories.predicates.ActivityPredicates
+import com.autentia.tnt.binnacle.repositories.predicates.PredicateBuilder
 import com.autentia.tnt.security.application.checkAuthentication
 import com.autentia.tnt.security.application.id
 import com.autentia.tnt.security.application.isAdmin
@@ -125,7 +126,7 @@ internal class ActivityRepositorySecured(
     private fun addUserFilterIfNecessary(activitySpecification: Specification<Activity>): Specification<Activity> {
         val authentication = securityService.checkAuthentication()
         return if (authentication.isNotAdmin()) {
-            activitySpecification.and(ActivityPredicates.userId(authentication.id()))
+            PredicateBuilder.and(activitySpecification, ActivityPredicates.userId(authentication.id()))
         } else {
             activitySpecification
         }

--- a/tntconcept-binnacle/src/main/kotlin/com/autentia/tnt/binnacle/repositories/predicates/ActivityPredicates.kt
+++ b/tntconcept-binnacle/src/main/kotlin/com/autentia/tnt/binnacle/repositories/predicates/ActivityPredicates.kt
@@ -32,6 +32,17 @@ class ActivityIdSpecification(private val id: Long) : Specification<Activity> {
     override fun toString(): String {
         return "activity.id==$id"
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ActivityIdSpecification) return false
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
 }
 
 class ActivityApprovalStateSpecification(private val approvalState: ApprovalState) :
@@ -58,8 +69,6 @@ class ActivityApprovalStateSpecification(private val approvalState: ApprovalStat
     override fun hashCode(): Int {
         return approvalState.hashCode()
     }
-
-
 }
 
 class ActivityRoleIdSpecification(private val roleId: Long) : Specification<Activity> {
@@ -85,8 +94,6 @@ class ActivityRoleIdSpecification(private val roleId: Long) : Specification<Acti
     override fun hashCode(): Int {
         return roleId.hashCode()
     }
-
-
 }
 
 class ActivityProjectIdSpecification(private val projectId: Long) : Specification<Activity> {
@@ -169,8 +176,6 @@ class ActivityStartDateLessOrEqualSpecification(private val startDate: LocalDate
     override fun hashCode(): Int {
         return startDate.hashCode()
     }
-
-
 }
 
 class ActivityEndDateGreaterOrEqualSpecification(private val endDate: LocalDate) : Specification<Activity> {
@@ -196,7 +201,6 @@ class ActivityEndDateGreaterOrEqualSpecification(private val endDate: LocalDate)
     override fun hashCode(): Int {
         return endDate.hashCode()
     }
-
 }
 
 class ActivityUserIdSpecification(private val userId: Long) : Specification<Activity> {
@@ -222,6 +226,4 @@ class ActivityUserIdSpecification(private val userId: Long) : Specification<Acti
     override fun hashCode(): Int {
         return userId.hashCode()
     }
-
-
 }

--- a/tntconcept-binnacle/src/main/kotlin/com/autentia/tnt/binnacle/usecases/ActivitiesByFilterUseCase.kt
+++ b/tntconcept-binnacle/src/main/kotlin/com/autentia/tnt/binnacle/usecases/ActivitiesByFilterUseCase.kt
@@ -35,11 +35,11 @@ class ActivitiesByFilterUseCase internal constructor(
             predicate = PredicateBuilder.and(predicate, approvalState(activityFilter.approvalState))
         }
 
-        if (activityFilter.startDate !== null) {
-            predicate = PredicateBuilder.and(predicate, startDateLessThanOrEqualTo(activityFilter.startDate))
-        }
         if (activityFilter.endDate !== null) {
-            predicate = PredicateBuilder.and(predicate, endDateGreaterThanOrEqualTo(activityFilter.endDate))
+            predicate = PredicateBuilder.and(predicate, startDateLessThanOrEqualTo(activityFilter.endDate))
+        }
+        if (activityFilter.startDate !== null) {
+            predicate = PredicateBuilder.and(predicate, endDateGreaterThanOrEqualTo(activityFilter.startDate))
         }
 
         if (activityFilter.roleId !== null) {

--- a/tntconcept-binnacle/src/test/kotlin/com/autentia/tnt/binnacle/repositories/ActivityRepositorySecuredTest.kt
+++ b/tntconcept-binnacle/src/test/kotlin/com/autentia/tnt/binnacle/repositories/ActivityRepositorySecuredTest.kt
@@ -14,10 +14,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.Mockito
-import org.mockito.Mockito.any
 import org.mockito.Mockito.mock
-import org.mockito.kotlin.argThat
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.LocalDate
@@ -50,14 +47,11 @@ internal class ActivityRepositorySecuredTest {
         val activitySpecification = PredicateBuilder.and(ActivityPredicates.ALL, ActivityPredicates.userId(userId))
 
         whenever(securityService.authentication).thenReturn(Optional.of(authenticationWithoutAdminRole))
-        whenever(activityDao.findAll(any())).thenReturn(activities)
+        whenever(activityDao.findAll(activitySpecification)).thenReturn(activities)
 
         val result = activityRepositorySecured.findAll(ActivityPredicates.ALL)
 
         assertEquals(activities, result)
-        Mockito.verify(activityDao).findAll(argThat { argActivitySpecification ->
-            activitySpecification.toString() == argActivitySpecification.toString()
-        })
     }
 
     @Test
@@ -79,14 +73,11 @@ internal class ActivityRepositorySecuredTest {
         val activitySpecification = ActivityPredicates.ALL
 
         whenever(securityService.authentication).thenReturn(Optional.of(authenticationWithAdminRole))
-        whenever(activityDao.findAll(any())).thenReturn(activities)
+        whenever(activityDao.findAll(activitySpecification)).thenReturn(activities)
 
         val result = activityRepositorySecured.findAll(ActivityPredicates.ALL)
 
         assertEquals(activities, result)
-        Mockito.verify(activityDao).findAll(argThat { argActivitySpecification ->
-            activitySpecification.toString() == argActivitySpecification.toString()
-        })
     }
 
     @Test

--- a/tntconcept-binnacle/src/test/kotlin/com/autentia/tnt/binnacle/repositories/ActivityRepositorySecuredTest.kt
+++ b/tntconcept-binnacle/src/test/kotlin/com/autentia/tnt/binnacle/repositories/ActivityRepositorySecuredTest.kt
@@ -6,13 +6,18 @@ import com.autentia.tnt.binnacle.core.domain.ActivityTimeOnly
 import com.autentia.tnt.binnacle.entities.Activity
 import com.autentia.tnt.binnacle.entities.ApprovalState
 import com.autentia.tnt.binnacle.entities.TimeUnit
+import com.autentia.tnt.binnacle.repositories.predicates.ActivityPredicates
+import com.autentia.tnt.binnacle.repositories.predicates.PredicateBuilder
 import io.micronaut.security.authentication.ClientAuthentication
 import io.micronaut.security.utils.SecurityService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito
+import org.mockito.Mockito.any
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.LocalDate
@@ -25,6 +30,64 @@ internal class ActivityRepositorySecuredTest {
     private val activityDao = mock<ActivityDao>()
 
     private var activityRepositorySecured = ActivityRepositorySecured(activityDao, securityService)
+
+    @Test
+    fun `find all with user id filter`() {
+        val activities = listOf(
+            Activity(
+                id = 1L,
+                start = today.atTime(10, 0, 0),
+                end = today.atTime(12, 0, 0),
+                duration = 120,
+                description = "Test activity",
+                projectRole = projectRole,
+                userId = userId,
+                billable = false,
+                hasEvidences = false,
+                approvalState = ApprovalState.NA
+            )
+        )
+        val activitySpecification = PredicateBuilder.and(ActivityPredicates.ALL, ActivityPredicates.userId(userId))
+
+        whenever(securityService.authentication).thenReturn(Optional.of(authenticationWithoutAdminRole))
+        whenever(activityDao.findAll(any())).thenReturn(activities)
+
+        val result = activityRepositorySecured.findAll(ActivityPredicates.ALL)
+
+        assertEquals(activities, result)
+        Mockito.verify(activityDao).findAll(argThat { argActivitySpecification ->
+            activitySpecification.toString() == argActivitySpecification.toString()
+        })
+    }
+
+    @Test
+    fun `find all without user id filter`() {
+        val activities = listOf(
+            Activity(
+                id = 2L,
+                start = today.atTime(10, 0, 0),
+                end = today.atTime(12, 0, 0),
+                duration = 120,
+                description = "Test activity",
+                projectRole = projectRole,
+                userId = userId,
+                billable = false,
+                hasEvidences = false,
+                approvalState = ApprovalState.NA
+            )
+        )
+        val activitySpecification = ActivityPredicates.ALL
+
+        whenever(securityService.authentication).thenReturn(Optional.of(authenticationWithAdminRole))
+        whenever(activityDao.findAll(any())).thenReturn(activities)
+
+        val result = activityRepositorySecured.findAll(ActivityPredicates.ALL)
+
+        assertEquals(activities, result)
+        Mockito.verify(activityDao).findAll(argThat { argActivitySpecification ->
+            activitySpecification.toString() == argActivitySpecification.toString()
+        })
+    }
 
     @Test
     fun `find activity should throw illegal state exception`() {

--- a/tntconcept-binnacle/src/test/kotlin/com/autentia/tnt/binnacle/usecases/ActivitiesByFilterUseCaseTest.kt
+++ b/tntconcept-binnacle/src/test/kotlin/com/autentia/tnt/binnacle/usecases/ActivitiesByFilterUseCaseTest.kt
@@ -61,8 +61,8 @@ internal class ActivitiesByFilterUseCaseTest {
         )
         val compositedSpecification =
             PredicateBuilder.and(
-                ActivityStartDateLessOrEqualSpecification(activityFilterDTO.startDate!!),
-                ActivityEndDateGreaterOrEqualSpecification(activityFilterDTO.endDate!!)
+                ActivityStartDateLessOrEqualSpecification(activityFilterDTO.endDate!!),
+                ActivityEndDateGreaterOrEqualSpecification(activityFilterDTO.startDate!!)
             )
         whenever(activityService.getActivities(compositedSpecification)).thenReturn(listOf(activity))
         whenever(activityResponseConverter.mapActivitiesToActivitiesResponseDTO(listOf(activity))).thenReturn(
@@ -135,8 +135,8 @@ internal class ActivitiesByFilterUseCaseTest {
         val compositedSpecification =
             PredicateBuilder.and(
                 PredicateBuilder.and(
-                    ActivityStartDateLessOrEqualSpecification(activityFilterDTO.startDate!!),
-                    ActivityEndDateGreaterOrEqualSpecification(activityFilterDTO.endDate!!)
+                    ActivityStartDateLessOrEqualSpecification(activityFilterDTO.endDate!!),
+                    ActivityEndDateGreaterOrEqualSpecification(activityFilterDTO.startDate!!)
                 ), ActivityProjectIdSpecification(activityFilterDTO.projectId!!)
             )
 


### PR DESCRIPTION
Currently, we are filtering activities out of the start-end dates interval. This PR ensures that the start and end date specifications are filtering the activities within the start-end interval given an activityFilter. 