### PR TITLE
fix(git): modification of .gitignore to discard any docker-compose.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,5 @@ tntconcept-ddbb/src/main/resources/db/migration/R__*
 utils/R__*
 
 ### Docker ###
-docker-compose.local.yml
+docker-compose*.local.yml
 .mysql


### PR DESCRIPTION
## Describe your changes

- Actualización del .gitignore para que tenga en cuenta e ignore cualquier fichero que empiece por docker-compose y termine con .local

El cambio surge de la necesidad de disponer de un fichero docker-compose-colima-M1.local diferente al original por las diferencias del equipo.

## Issue ticket number and link

En este caso no disponemos de issue relaccionada ya que es un cambio surgido a partir de la preparación del entorno de 9desarrollo.

## Review / Tests

- [ ] Comprobar que si disponemos en el entorno local de un fichero que cumpla con el patrón establecido se ignora y nunca estará disponible para subir al repositorio.


