### PR TITLE
fix: Remove drop table from migration

### DIFF
--- a/tntconcept-ddbb/src/main/resources/db/migration/V015__attachments.sql
+++ b/tntconcept-ddbb/src/main/resources/db/migration/V015__attachments.sql
@@ -1,5 +1,3 @@
-DROP TABLE IF EXISTS `Attachment`;
-
 CREATE TABLE `Attachment` (
     id              VARCHAR(36)  NOT NULL,
     userId          INT          NOT NULL,


### PR DESCRIPTION
A `DROP TABLE` is deleted in a not applied migration